### PR TITLE
Update Invalidation.php

### DIFF
--- a/src/Cache/Invalidation.php
+++ b/src/Cache/Invalidation.php
@@ -677,8 +677,8 @@ class Invalidation {
 		// get the post object being modified
 		$post = get_post( $post_id );
 
-		// if the post type is not nav menu item, ignore it
-		if ( 'nav_menu_item' !== $post->post_type ) {
+		// if the post is not found or the post type is not nav menu item, ignore it
+		if ( !$post || 'nav_menu_item' !== $post->post_type ) {
 			return;
 		}
 


### PR DESCRIPTION
**ErrorException**
`Warning: Attempt to read property "post_type" on null`


In this updated code, the condition $post checks whether the $post variable is not null before accessing its post_type property. If $post is null, the code immediately returns without attempting to access its properties.